### PR TITLE
Add the library badge for Mod Menu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,6 +16,13 @@
   "entrypoints": {
     "main": ["fr.catcore.server.translations.ServerTranslationsInitializer"]
   },
+  "custom": {
+    "modmenu": {
+      "badges": [
+        "library"
+      ]
+    }
+  },
   "depends": {
     "minecraft": ">=1.16",
     "fabricloader": ">=0.9.0+build.204",


### PR DESCRIPTION
This pull request adds custom metadata to `fabric.mod.json` that Mod Menu uses to show the library badge in its mod list.